### PR TITLE
Use .eval instead of .eval_ when logging errors

### DIFF
--- a/core/src/main/scala/quasar/plugin/jdbc/destination/JdbcCreateSink.scala
+++ b/core/src/main/scala/quasar/plugin/jdbc/destination/JdbcCreateSink.scala
@@ -92,7 +92,7 @@ object JdbcCreateSink {
       sunk = jdbcSink(hygienicRef, hygienicColumns, instrumentedBytes) ++ Stream.eval_(ingestSucceeded)
 
       out = sunk onError {
-        case t => Stream.eval_(for {
+        case t => Stream.eval(for {
           failedAt <- timer.clock.monotonic(MILLISECONDS)
           elapsed = Duration.ofMillis(failedAt - startAt)
           progress <- totalBytes.get


### PR DESCRIPTION
`eval_` short circuits any further monadic binds, causing the `raiseError` that rethrows the logged error from being sequenced, halting propagation.

[ch11594]