### PR TITLE
Flow/v1

### DIFF
--- a/core/src/main/scala/quasar/lib/jdbc/destination/flow/Flow.scala
+++ b/core/src/main/scala/quasar/lib/jdbc/destination/flow/Flow.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2020 Precog Data
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.lib.jdbc.destination.flow
+
+import scala.Unit
+
+import cats.~>
+
+import doobie._
+
+import fs2.Chunk
+import quasar.connector.IdBatch
+
+trait Flow[A] { self =>
+  def ingest(chunk: Chunk[A]): ConnectionIO[Unit]
+  def delete(ids: IdBatch): ConnectionIO[Unit]
+  def replace: ConnectionIO[Unit]
+  def append: ConnectionIO[Unit]
+
+  def mapK(f: ConnectionIO ~> ConnectionIO) = new Flow[A] {
+    def ingest(chunk: Chunk[A]) = f(self.ingest(chunk))
+    def delete(ids: IdBatch): ConnectionIO[Unit] = f(self.delete(ids))
+    def replace = f(self.replace)
+    def append = f(self.append)
+  }
+}

--- a/core/src/main/scala/quasar/lib/jdbc/destination/flow/FlowArgs.scala
+++ b/core/src/main/scala/quasar/lib/jdbc/destination/flow/FlowArgs.scala
@@ -31,8 +31,8 @@ sealed trait FlowArgs[T] {
   val path: ResourcePath
   val writeMode: QWriteMode
   val columns: NonEmptyList[Column[T]]
-  val idColumn: Option[Column[_]]
-  val filterColumn: Option[Column[_]]
+  val idColumn: Option[Column[T]]
+  val filterColumn: Option[Column[T]]
 }
 
 object FlowArgs {

--- a/core/src/main/scala/quasar/lib/jdbc/destination/flow/FlowArgs.scala
+++ b/core/src/main/scala/quasar/lib/jdbc/destination/flow/FlowArgs.scala
@@ -27,8 +27,6 @@ import quasar.api.Column
 import quasar.api.resource.ResourcePath
 import quasar.connector.destination.{WriteMode => QWriteMode, ResultSink}, ResultSink.{UpsertSink, AppendSink}
 
-import org.slf4s.Logger
-
 sealed trait FlowArgs[T] {
   val path: ResourcePath
   val writeMode: QWriteMode

--- a/core/src/main/scala/quasar/lib/jdbc/destination/flow/FlowArgs.scala
+++ b/core/src/main/scala/quasar/lib/jdbc/destination/flow/FlowArgs.scala
@@ -63,7 +63,3 @@ object FlowArgs {
     val filterColumn = None
   }
 }
-
-
-
-

--- a/core/src/main/scala/quasar/lib/jdbc/destination/flow/FlowArgs.scala
+++ b/core/src/main/scala/quasar/lib/jdbc/destination/flow/FlowArgs.scala
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2020 Precog Data
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.lib.jdbc.destination.flow
+
+import slamdata.Predef._
+
+import slamdata.Predef._
+
+import cats.data.NonEmptyList
+import cats.implicits._
+
+import quasar.api.Column
+import quasar.api.resource.ResourcePath
+import quasar.connector.destination.{WriteMode => QWriteMode, ResultSink}, ResultSink.{UpsertSink, AppendSink}
+
+import org.slf4s.Logger
+
+sealed trait FlowArgs[T] {
+  val path: ResourcePath
+  val writeMode: QWriteMode
+  val columns: NonEmptyList[Column[T]]
+  val idColumn: Option[Column[_]]
+  val filterColumn: Option[Column[_]]
+}
+
+object FlowArgs {
+  def ofUpsert[T](upsert: UpsertSink.Args[T]): FlowArgs[T] = new FlowArgs[T] {
+    val path = upsert.path
+    val writeMode = upsert.writeMode
+    val columns = upsert.columns
+    val idColumn = upsert.idColumn.some
+    val filterColumn = upsert.idColumn.some
+  }
+
+  def ofAppend[T](append: AppendSink.Args[T]): FlowArgs[T] = new FlowArgs[T] {
+    val path = append.path
+    val writeMode = append.writeMode
+    val columns = append.columns
+    val idColumn = append.pushColumns.primary
+    val filterColumn = None
+  }
+
+  def ofCreate[T](
+      resourcePath: ResourcePath,
+      inpColumns: NonEmptyList[Column[T]])
+      : FlowArgs[T] = new FlowArgs[T] {
+    val path = resourcePath
+    val writeMode = QWriteMode.Replace
+    val columns = inpColumns
+    val idColumn = None
+    val filterColumn = None
+  }
+}
+
+
+
+

--- a/core/src/main/scala/quasar/lib/jdbc/destination/flow/FlowSinks.scala
+++ b/core/src/main/scala/quasar/lib/jdbc/destination/flow/FlowSinks.scala
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2020 Precog Data
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.lib.jdbc.destination.flow
+
+import slamdata.Predef._
+
+import cats.data._
+import cats.effect._
+import cats.implicits._
+
+import doobie._
+import doobie.implicits._
+
+import fs2.{Pipe, Stream}
+
+import quasar.api.Column
+import quasar.api.push.OffsetKey
+import quasar.api.resource._
+import quasar.connector._
+import quasar.connector.destination.ResultSink, ResultSink.{UpsertSink, AppendSink}
+import quasar.connector.render.RenderConfig
+
+import org.slf4s.Logger
+
+import skolems.∀
+
+import implicits._
+
+trait FlowSinks[F[_], T, C] {
+  type Consume[Event[_], A] =
+    Pipe[F, Event[OffsetKey.Actual[A]], OffsetKey.Actual[A]]
+
+  def flowResource(args: FlowArgs[T]): Resource[F, Flow[C]]
+  def render(args: FlowArgs[T]): RenderConfig[C]
+  val flowTransactor: Transactor[F]
+  val flowLogger: Logger
+
+  def create(path: ResourcePath, cols: NonEmptyList[Column[T]])(implicit F: Bracket[F, Throwable])
+      : (RenderConfig[C], Pipe[F, C, Unit]) = {
+    val args = FlowArgs.ofCreate(path, cols)
+    (render(args), in => for {
+      flow <- Stream.resource(flowResource(args))
+      _ <- in.through(createPipe(flow))
+    } yield ())
+  }
+
+  def createPipe[A](flow: Flow[C])(implicit F: Bracket[F, Throwable]): Pipe[F, C, Unit] = { events =>
+    events.chunks.evalMap(c => flow.ingest(c).transact(flowTransactor)) ++
+      Stream.eval(flow.replace.transact(flowTransactor))
+  }
+
+  def upsert(upsertArgs: UpsertSink.Args[T])(implicit F: Sync[F])
+      : (RenderConfig[C], ∀[Consume[DataEvent[C, *], *]]) = {
+    val args = FlowArgs.ofUpsert(upsertArgs)
+    val consume = ∀[Consume[DataEvent[C, *], *]](upsertPipe(args))
+    (render(args), consume)
+  }
+
+  def append(appendArgs: AppendSink.Args[T])(implicit F: Sync[F])
+      : (RenderConfig[C], ∀[Consume[AppendEvent[C, *], *]]) = {
+    val args = FlowArgs.ofAppend(appendArgs)
+    val consume = ∀[Consume[AppendEvent[C, *], *]](upsertPipe(args))
+    (render(args), consume)
+  }
+
+  private def upsertPipe[A](args: FlowArgs[T])(implicit F: Sync[F])
+      : Pipe[F, DataEvent[C, OffsetKey.Actual[A]], OffsetKey.Actual[A]] = { events =>
+    for{
+      flow <- Stream.resource(flowResource(args))
+      offset <- events.through(upsertPipe0[C, OffsetKey.Actual[A]](flow).withLogger(flowLogger))
+    } yield offset
+  }
+
+  private def upsertPipe0[A, B](flow: Flow[A])(implicit F: Bracket[F, Throwable])
+      : Pipe[F, DataEvent[A, B], B] = { events =>
+    def handleEvent(event: DataEvent[A, B]): ConnectionIO[Option[B]] = event match {
+      case DataEvent.Create(chunk) =>
+        flow.ingest(chunk) >>
+        none[B].pure[ConnectionIO]
+      case DataEvent.Delete(ids) =>
+        flow.delete(ids) >>
+        none[B].pure[ConnectionIO]
+      case DataEvent.Commit(offset) =>
+        flow.replace >>
+        offset.some.pure[ConnectionIO]
+    }
+    events.evalMap(x => handleEvent(x).transact(flowTransactor)).unNone
+  }
+}
+

--- a/core/src/main/scala/quasar/lib/jdbc/destination/flow/FlowSinks.scala
+++ b/core/src/main/scala/quasar/lib/jdbc/destination/flow/FlowSinks.scala
@@ -49,6 +49,10 @@ trait FlowSinks[F[_], T, C] {
   val flowTransactor: Transactor[F]
   val flowLogger: Logger
 
+
+  def flowSinks(implicit F: Sync[F]): NonEmptyList[ResultSink[F, T]] =
+    NonEmptyList.of(ResultSink.create(create), ResultSink.upsert(upsert), ResultSink.append(append))
+
   def create(path: ResourcePath, cols: NonEmptyList[Column[T]])(implicit F: Bracket[F, Throwable])
       : (RenderConfig[C], Pipe[F, C, Unit]) = {
     val args = FlowArgs.ofCreate(path, cols)

--- a/core/src/main/scala/quasar/lib/jdbc/destination/flow/Retry.scala
+++ b/core/src/main/scala/quasar/lib/jdbc/destination/flow/Retry.scala
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2020 Precog Data
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.lib.jdbc.destination.flow
+
+import slamdata.Predef._
+
+import cats.{~>, MonadError}
+import cats.effect._
+import cats.implicits._
+
+import doobie._
+import doobie.implicits._
+import doobie.free.connection.rollback
+
+import scala.concurrent.duration.FiniteDuration
+
+object Retry {
+  def apply[F[_]: Effect: Timer](maxN: Int, timeout: FiniteDuration): ConnectionIO ~> ConnectionIO =
+    natural(maxN, timeout, 0)
+
+  private def natural[F[_]: Effect: Timer](maxN: Int, timeout: FiniteDuration, n: Int)
+      : ConnectionIO ~> ConnectionIO = λ[ConnectionIO ~> ConnectionIO] { action =>
+    action.attempt flatMap {
+      case Right(a) => a.pure[ConnectionIO]
+      case Left(e) if n < maxN =>
+        rollback >>
+        toConnectionIO[F].apply(Timer[F].sleep(timeout)) >>
+        natural[F](maxN, timeout, n + 1).apply(action)
+      case Left(e) =>
+        MonadError[ConnectionIO, Throwable].raiseError(e)
+    }
+  }
+  private def toConnectionIO[F[_]: Effect]: F ~> ConnectionIO =
+    Effect.toIOK[F] andThen LiftIO.liftK[ConnectionIO]
+}

--- a/core/src/main/scala/quasar/lib/jdbc/destination/flow/implicits.scala
+++ b/core/src/main/scala/quasar/lib/jdbc/destination/flow/implicits.scala
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2020 Precog Data
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.lib.jdbc.destination.flow
+
+import slamdata.Predef._
+
+import cats.data._
+import cats.effect.{Effect, Sync}
+import cats.implicits._
+
+import doobie._
+import doobie.implicits._
+
+import fs2.{Pipe, Stream}
+
+import quasar.api.Column
+import quasar.api.push.OffsetKey
+import quasar.api.resource._
+import quasar.connector._
+import quasar.connector.destination.{WriteMode => QWriteMode, ResultSink}, ResultSink.{UpsertSink, AppendSink}
+import quasar.connector.render.RenderConfig
+import quasar.lib.jdbc.destination.WriteMode
+
+import org.slf4s.Logger
+
+import skolems.∀
+
+object implicits {
+  implicit class PipeLogger[F[_]: Sync, A, B, C](pipe: Pipe[F, DataEvent[C, OffsetKey.Actual[A]], B]) {
+    def withLogger(logger: Logger): Pipe[F, DataEvent[C, OffsetKey.Actual[A]], B] = { events =>
+      def trace(msg: => String) = Sync[F].delay(logger.trace(msg))
+
+      def logEvents(event: DataEvent[_, _]): F[Unit] = trace { event match {
+        case DataEvent.Create(chunk) =>
+          s"Loading chunk with size: ${chunk.size}"
+        case DataEvent.Delete(idBatch) =>
+          s"Deleting ${idBatch.size} records"
+        case DataEvent.Commit(_) =>
+          "Commit"
+      }}
+      events.evalTap(logEvents).through(pipe.logStartAndEnd(logger))
+    }
+  }
+
+  implicit class StartEndLogger[F[_]: Sync, A, B](pipe: Pipe[F, A, B]) {
+    def logStartAndEnd(logger: Logger): Pipe[F, A, B] = { events =>
+      def trace(msg: => String) = Sync[F].delay(logger.trace(msg))
+      Stream.eval_(trace("Strating load")) ++
+      events.through(pipe) ++
+      Stream.eval_(trace("Finished load"))
+    }
+  }
+}

--- a/core/src/main/scala/quasar/lib/jdbc/destination/flow/implicits.scala
+++ b/core/src/main/scala/quasar/lib/jdbc/destination/flow/implicits.scala
@@ -18,26 +18,14 @@ package quasar.lib.jdbc.destination.flow
 
 import slamdata.Predef._
 
-import cats.data._
-import cats.effect.{Effect, Sync}
-import cats.implicits._
-
-import doobie._
-import doobie.implicits._
+import cats.effect.Sync
 
 import fs2.{Pipe, Stream}
 
-import quasar.api.Column
 import quasar.api.push.OffsetKey
-import quasar.api.resource._
 import quasar.connector._
-import quasar.connector.destination.{WriteMode => QWriteMode, ResultSink}, ResultSink.{UpsertSink, AppendSink}
-import quasar.connector.render.RenderConfig
-import quasar.lib.jdbc.destination.WriteMode
 
 import org.slf4s.Logger
-
-import skolems.∀
 
 object implicits {
   implicit class PipeLogger[F[_]: Sync, A, B, C](pipe: Pipe[F, DataEvent[C, OffsetKey.Actual[A]], B]) {


### PR DESCRIPTION
[ch13042] 

This is extracts sink building machinery from destinations. I haven't come up with nice approach for `TempTableFlow` deduplication, it's either too brittle for usage in callsite or too generic and barely useful. Will return to this after Snowflake dest update. Although `Flow.delete` seems to be YAGNI case I'd say that we should have it and provide `().pure[ConnectionIO]` in destinations, to make flow intentions a bit clearer. 

`0.34.0-82cd35b` snapshotted